### PR TITLE
Add prefix safe function

### DIFF
--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -514,7 +514,7 @@ public class JsonRpc2_0Web3j implements Web3j {
     public Request<?, EthLog> ethGetFilterLogs(BigInteger filterId) {
         return new Request<>(
                 "eth_getFilterLogs",
-                Arrays.asList(Numeric.encodeQuantity(filterId)),
+                Arrays.asList(Numeric.toHexStringWithPrefixSave(filterId)),
                 web3jService,
                 EthLog.class);
     }

--- a/utils/src/main/java/org/web3j/utils/Numeric.java
+++ b/utils/src/main/java/org/web3j/utils/Numeric.java
@@ -112,6 +112,14 @@ public final class Numeric {
     public static String toHexStringWithPrefixZeroPadded(BigInteger value, int size) {
         return toHexStringZeroPadded(value, size, true);
     }
+    
+    public static String toHexStringWithPrefixSave(BigInteger value) {
+        String result = toHexStringNoPrefix(value);
+        if (result.length() < 2) {
+            result = Strings.zeros(1) + result;
+        }
+        return HEX_PREFIX + result;
+    }
 
     public static String toHexStringNoPrefixZeroPadded(BigInteger value, int size) {
         return toHexStringZeroPadded(value, size, false);


### PR DESCRIPTION
Start a bug-fix where filters don't work with testrpc because of the way testrpc expects to receive the filter.